### PR TITLE
feat: CI workflow 추가 #2

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,7 +14,6 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./backend
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## ⭐️ Issue Number
- #2 

## 🚩 Summary
- Github Action을 사용한 CI Workflow를 추가했습니다.
- `develop` 브랜치와 `main` 브랜치에 pr이 열릴 때 트리거되도록 설정했습니다.
- Gradle 빌드 및 테스트를 수행합니다.
